### PR TITLE
brand 50x.html page for icds-cas

### DIFF
--- a/pages/50x.html
+++ b/pages/50x.html
@@ -17,10 +17,9 @@
                     </div>
                     <div class="col-sm-6 container-welcome">
                         <div class="welcome-container-inner">
-                            <h1>CommCareHQ is currently undergoing maintenance</h1>
+                            <h1>ICDS-CAS Server is currently unavailable, it will be back shortly</h1>
                             <p class="lead">
-                                We will be back online as soon as possible, please check the
-                                <a class="status-link" href="http://www.dimagi.com/maintenance-updates/">status blog</a> for more information.
+                                We will be back online as soon as possible.
                             </p>
                         </div>
                     </div>

--- a/pages/error_style/style.css
+++ b/pages/error_style/style.css
@@ -394,43 +394,6 @@ select[multiple].form-group-xl .form-control {
   top: 50%;
   left: 50%;
 }
-@media (min-width: 768px) {
-  .flower-home {
-    width: 290px;
-    height: 290px;
-    margin-top: -145px;
-    margin-left: -145px;
-    background-image: url('../images/flower-home/flower-home-sm.png');
-  }
-}
-@media (min-width: 992px) {
-  .flower-home {
-    width: 380px;
-    height: 380px;
-    margin-top: -190px;
-    margin-left: -190px;
-    background-image: url('../images/flower-home/flower-home-md.png');
-  }
-}
-@media (min-width: 1200px) {
-  .flower-home {
-    width: 465px;
-    height: 465px;
-    margin-top: -232.5px;
-    margin-left: -232.5px;
-    background-image: url('../images/flower-home/flower-home-lg.png');
-  }
-}
-@media (max-width: 767px) {
-  .flower-home {
-    width: 280px;
-    height: 280px;
-    margin-top: -140px;
-    margin-left: -140px;
-    top: 330px;
-    background-image: url('../images/flower-home/flower-home-xs.png');
-  }
-}
 .flower-icon {
   position: absolute;
   display: block;


### PR DESCRIPTION
Note this PR is into `master-icds`

My plan is to use a permanent `master-icds` branch for the icds-branded page. Given how simple the pages and the diff is, this right now seems easier than reorganizing the repo to contain different directories for different versions. Should this for some reason ever become burdensome, we could undergo that reorganization at that time.

<img width="1437" alt="screen shot 2017-07-10 at 11 53 57 am" src="https://user-images.githubusercontent.com/137212/28027267-88d6ffd2-6566-11e7-9de0-70d26c35f0a6.png">
