### PR TITLE
remove Dimagi copyright (master-icds)

### DIFF
--- a/pages/400.html
+++ b/pages/400.html
@@ -30,9 +30,5 @@
                 <p class="text-copyright text-center"></p>
             </div>
         </footer>
-        <script>
-            var copyrightEl = document.getElementsByClassName('text-copyright')[0];
-            copyrightEl.innerHTML = 'Copyright &copy; ' + (new Date()).getFullYear() + ' Dimagi, Inc.';
-        </script>
     </body>
 </html>

--- a/pages/50x.html
+++ b/pages/50x.html
@@ -31,9 +31,5 @@
                 <p class="text-copyright text-center"></p>
             </div>
         </footer>
-        <script>
-            var copyrightEl = document.getElementsByClassName('text-copyright')[0];
-            copyrightEl.innerHTML = 'Copyright &copy; ' + (new Date()).getFullYear() + ' Dimagi, Inc.';
-        </script>
     </body>
 </html>


### PR DESCRIPTION
No longer shows up in the footer as per https://manage.dimagi.com/default.asp?251530:

<img width="1440" alt="screen shot 2017-07-11 at 11 18 06 am" src="https://user-images.githubusercontent.com/137212/28075823-a4b74a1c-662a-11e7-979f-342543650202.png">
